### PR TITLE
Support for java.time classes

### DIFF
--- a/src/main/java/com/github/drapostolos/typeparser/Parsers.java
+++ b/src/main/java/com/github/drapostolos/typeparser/Parsers.java
@@ -12,6 +12,9 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.NumberFormat;
 import java.text.ParseException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -86,7 +89,10 @@ enum Parsers implements Parser<Object> {
 		} catch (ParseException e) {
 			throw new IllegalArgumentException(e.getMessage(), e);
 		}}),
-    PATH(Path.class, (input,helper) -> Paths.get(input.trim()));
+    PATH(Path.class, (input,helper) -> Paths.get(input.trim())),
+	LOCAL_DATE(LocalDate.class, (input, helper) -> LocalDate.parse(input.trim())),
+	LOCAL_TIME(LocalTime.class, (input, helper) -> LocalTime.parse(input.trim())),
+	LOCA_DATE_TIME(LocalDateTime.class, (input, helper) -> LocalDateTime.parse(input.trim()));
 
 	private static final Map<Type, Parser<?>> DEFAULT_PARSERS;
 	private List<Type> types = new ArrayList<>();

--- a/src/test/java/com/github/drapostolos/typeparser/LocalDateTest.java
+++ b/src/test/java/com/github/drapostolos/typeparser/LocalDateTest.java
@@ -1,0 +1,69 @@
+package com.github.drapostolos.typeparser;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class LocalDateTest extends AbstractTypeTester<LocalDate> {
+
+    private static final String DATES = "2025-01-14, 2025-01-15, 2025-01-16";
+
+    @Override
+    LocalDate make(String string) throws Exception {
+        return LocalDate.parse(string.trim());
+    }
+
+    @Test
+    public void canParseStringToLocalDateType() throws Exception {
+        canParse("2025-01-14").toType(LocalDate.class);
+        canParse("\t2025-01-14").toType(LocalDate.class);
+    }
+
+    @Test
+    public void shouldThrowWhenReverseDate() throws Exception {
+        shouldThrowTypeParserException()
+            .containingErrorMessage("Can not parse \"2025-14-01\"")
+            .containingErrorMessage("due to: Text '2025-14-01' could not be parsed:")
+            .containingErrorMessage("Invalid value for MonthOfYear (valid values 1 - 12): 14")
+            .whenParsing("2025-14-01")
+            .to(LocalDate.class);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenStringIsNotDate() throws Exception {
+        shouldThrowTypeParserException()
+            .containingErrorMessage("Can not parse \"zarifovoe\"")
+            .containingErrorMessage("due to: Text 'zarifovoe' could not be parsed at index 0")
+            .whenParsing("zarifovoe")
+            .to(LocalDate.class);
+    }
+
+    @Test
+    public void canParseToGenericLocalDateArray() throws Exception {
+        canParse(DATES).toGenericArray(new GenericType<LocalDate[]>() {});
+    }
+
+    @Test
+    public void canParseToLocalLocalDateArray() throws Exception {
+        canParse(DATES).toArray(LocalDate[].class);
+    }
+
+    @Test
+    public void canParseToLocalDateList() throws Exception {
+        canParse(DATES).toArrayList(new GenericType<List<LocalDate>>() {});
+    }
+
+    @Test
+    public void canParseToLocalDateSet() throws Exception {
+        canParse("2025-01-14, 2025-01-15, 2025-01-15").toLinkedHashSet(new GenericType<Set<LocalDate>>() {});
+    }
+
+    @Test
+    public void canParseToLocalDateMap() throws Exception {
+        canParse("2025-01-14=2025-01-16, 2025-01-15=2025-01-17")
+            .toLinkedHashMap(new GenericType<Map<LocalDate, LocalDate>>() {});
+    }
+}

--- a/src/test/java/com/github/drapostolos/typeparser/LocalDateTimeTest.java
+++ b/src/test/java/com/github/drapostolos/typeparser/LocalDateTimeTest.java
@@ -1,0 +1,84 @@
+package com.github.drapostolos.typeparser;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class LocalDateTimeTest extends AbstractTypeTester<LocalDateTime> {
+
+    private static final String DATE_TIMES = "2025-01-14T14:30:15, 2025-01-14T14:30:16, 2025-01-14T14:30:17";
+
+    @Override
+    LocalDateTime make(String string) throws Exception {
+        return LocalDateTime.parse(string.trim());
+    }
+
+    @Test
+    public void canParseStringToLocalDateTimeType() throws Exception {
+        canParse("2025-01-14T14:30:15").toType(LocalDateTime.class);
+        canParse("\t2025-01-14T14:30:15").toType(LocalDateTime.class);
+        canParse("2025-01-14T14:30:15.123456789").toType(LocalDateTime.class);
+        canParse("\t2025-01-14T14:30:15.123456789").toType(LocalDateTime.class);
+    }
+
+    @Test
+    public void shouldThrowWhenWrongDate() throws Exception {
+        shouldThrowTypeParserException()
+            .containingErrorMessage("Can not parse \"2025-14-01T14:30:15\"")
+            .containingErrorMessage("due to: Text '2025-14-01T14:30:15' could not be parsed:")
+            .containingErrorMessage("Invalid value for MonthOfYear (valid values 1 - 12): 14")
+            .whenParsing("2025-14-01T14:30:15")
+            .to(LocalDateTime.class);
+    }
+
+    @Test
+    public void shouldThrowWhenWrongTime() throws Exception {
+        shouldThrowTypeParserException()
+            .containingErrorMessage("Can not parse \"2025-01-14T14:300:15\"")
+            .containingErrorMessage("due to: Text '2025-01-14T14:300:15' could not be parsed")
+            .containingErrorMessage("unparsed text found at index 16")
+            .whenParsing("2025-01-14T14:300:15")
+            .to(LocalDateTime.class);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenStringIsNotDateTime() throws Exception {
+        shouldThrowTypeParserException()
+            .containingErrorMessage("Can not parse \"asda\"")
+            .containingErrorMessage("due to: Text 'asda' could not be parsed at index 0")
+            .whenParsing("asda")
+            .to(LocalDateTime.class);
+    }
+
+    @Test
+    public void canParseToGenericLocalDateTimeArray() throws Exception {
+        canParse(DATE_TIMES).toGenericArray(new GenericType<LocalDateTime[]>() {});
+    }
+
+    @Test
+    public void canParseToLocalLocalDateTimeArray() throws Exception {
+        canParse(DATE_TIMES).toArray(LocalDateTime[].class);
+    }
+
+    @Test
+    public void canParseToLocalDateTimeList() throws Exception {
+        canParse(DATE_TIMES).toArrayList(new GenericType<List<LocalDateTime>>() {});
+    }
+
+    @Test
+    public void canParseToLocalDateTimeSet() throws Exception {
+        canParse(
+            "2025-01-14T14:30:15, 2025-01-14T14:30:16, 2025-01-14T14:30:16"
+        ).toLinkedHashSet(new GenericType<Set<LocalDateTime>>() {});
+    }
+
+    @Test
+    public void canParseToLocalDateTimeMap() throws Exception {
+        canParse(
+            "2025-01-14T14:30:15=2025-01-14T14:30:17, 2025-01-14T14:30:16=2025-01-14T14:30:17"
+        ).toLinkedHashMap(new GenericType<Map<LocalDateTime, LocalDateTime>>() {});
+    }
+}

--- a/src/test/java/com/github/drapostolos/typeparser/LocalTimeTest.java
+++ b/src/test/java/com/github/drapostolos/typeparser/LocalTimeTest.java
@@ -1,0 +1,70 @@
+package com.github.drapostolos.typeparser;
+
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.junit.Test;
+
+public class LocalTimeTest extends AbstractTypeTester<LocalTime> {
+
+    private static final String TIMES = "14:30:15, 14:30:16, 14:30:17";
+
+    @Override
+    LocalTime make(String string) throws Exception {
+        return LocalTime.parse(string.trim());
+    }
+
+    @Test
+    public void canParseStringToLocalTimeType() throws Exception {
+        canParse("14:30:15").toType(LocalTime.class);
+        canParse("\t14:30:15").toType(LocalTime.class);
+        canParse("14:30:15.123456789").toType(LocalTime.class);
+        canParse("\t14:30:15.123456789").toType(LocalTime.class);
+    }
+
+    @Test
+    public void shouldThrowWhenWrongTime() throws Exception {
+        shouldThrowTypeParserException()
+            .containingErrorMessage("Can not parse \"140:30:15\"")
+            .containingErrorMessage("due to: Text '140:30:15' could not be parsed at index 2")
+            .whenParsing("140:30:15")
+            .to(LocalTime.class);
+    }
+
+    @Test
+    public void shouldThrowExceptionWhenStringIsNotTime() throws Exception {
+        shouldThrowTypeParserException()
+            .containingErrorMessage("Can not parse \"asda\"")
+            .containingErrorMessage("due to: Text 'asda' could not be parsed at index 0")
+            .whenParsing("asda")
+            .to(LocalTime.class);
+    }
+
+    @Test
+    public void canParseToGenericLocalTimeArray() throws Exception {
+        canParse(TIMES).toGenericArray(new GenericType<LocalTime[]>() {});
+    }
+
+    @Test
+    public void canParseToLocalLocalTimeArray() throws Exception {
+        canParse(TIMES).toArray(LocalTime[].class);
+    }
+
+    @Test
+    public void canParseToLocalTimeList() throws Exception {
+        canParse(TIMES).toArrayList(new GenericType<List<LocalTime>>() {});
+    }
+
+    @Test
+    public void canParseToLocalTimeSet() throws Exception {
+        canParse("14:30:15, 14:30:16, 14:30:16").toLinkedHashSet(new GenericType<Set<LocalTime>>() {});
+    }
+
+    @Test
+    public void canParseToLocalTimeMap() throws Exception {
+        canParse("14:30:15=14:30:17, 14:30:16=14:30:17")
+            .toLinkedHashMap(new GenericType<Map<LocalTime, LocalTime>>() {});
+    }
+}


### PR DESCRIPTION
Added parsers to `Parsers` as mentioned in [comment](https://github.com/drapostolos/type-parser/issues/50#issuecomment-1893558783)
Closes #50 